### PR TITLE
Remove unnecessary/broken migration

### DIFF
--- a/db/migrate/20180122021809_drop_minority_opinion_votes_table.rb
+++ b/db/migrate/20180122021809_drop_minority_opinion_votes_table.rb
@@ -1,5 +1,0 @@
-class DropMinorityOpinionVotesTable < ActiveRecord::Migration
-  def change
-    drop_table :minority_opinion_votes
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180122021809) do
+ActiveRecord::Schema.define(version: 20180115000053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This migration was trying to drop a table that never existed. Was able to deploy to EBS with this change.