### PR TITLE
Use literal SQL in migration

### DIFF
--- a/db/migrate/20180413200531_update_minority_opnions_associations.rb
+++ b/db/migrate/20180413200531_update_minority_opnions_associations.rb
@@ -1,9 +1,9 @@
 class UpdateMinorityOpnionsAssociations < ActiveRecord::Migration
   def change
-    MinorityOpinion.where(board_member_one: '').update_all(board_member_one: nil)
-    MinorityOpinion.where(board_member_two: '').update_all(board_member_two: nil)
-    MinorityOpinion.where(board_member_three: '').update_all(board_member_three: nil)
-    MinorityOpinion.where(board_member_four: '').update_all(board_member_four: nil)
+    MinorityOpinion.where("board_member_one = ''").update_all(board_member_one: nil)
+    MinorityOpinion.where("board_member_two = ''").update_all(board_member_two: nil)
+    MinorityOpinion.where("board_member_three = ''").update_all(board_member_three: nil)
+    MinorityOpinion.where("board_member_four = ''").update_all(board_member_four: nil)
 
     change_column :minority_opinions, :board_member_one, 'integer USING CAST(board_member_one AS integer)'
     change_column :minority_opinions, :board_member_two, 'integer USING CAST(board_member_two AS integer)'


### PR DESCRIPTION
This migration was failing because it was mapping to `board_member_one_id` in SQL, even though we hadn't created the column yet.

cc @vidurangaw 